### PR TITLE
serial: if using blocking API, block until transmission complete

### DIFF
--- a/drivers/source/SerialBase.cpp
+++ b/drivers/source/SerialBase.cpp
@@ -132,6 +132,9 @@ int SerialBase::_base_putc(int c)
 {
     // Mutex is already held
     serial_putc(&_serial, c);
+    while (!serial_transmission_complete(&_serial)) {
+        __asm("nop");
+    }
     return c;
 }
 

--- a/hal/include/hal/serial_api.h
+++ b/hal/include/hal/serial_api.h
@@ -282,6 +282,12 @@ int  serial_getc(serial_t *obj);
  */
 void serial_putc(serial_t *obj, int c);
 
+/** Check if the serial port has placed all data on the wire.
+ *
+ * @return 1 if the transmission is complete.
+ */
+bool serial_transmission_complete(serial_t *obj);
+
 /** Check if the serial peripheral is readable
  *
  * @param obj The serial object

--- a/targets/TARGET_STM/TARGET_STM32WL/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32WL/serial_device.c
@@ -169,6 +169,14 @@ int serial_getc(serial_t *obj)
     return (int)(huart->Instance->RDR & uhMask);
 }
 
+bool serial_transmission_complete(serial_t *obj) {
+    struct serial_s *obj_s = SERIAL_S(obj);
+    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
+
+    uint32_t transmission_complete = READ_BIT(huart->Instance->ISR, USART_ISR_TC) != 0;
+    return transmission_complete;
+}
+
 void serial_putc(serial_t *obj, int c)
 {
     struct serial_s *obj_s = SERIAL_S(obj);


### PR DESCRIPTION
There was no provision in the OS to check whether underlying serial hardware buffers had been drained. Wait for the TC bit to go high before returning when writing to serial using the blocking API.

FYI @pat-farmblox 

Before change:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/87753499-2f46-4b61-b967-7b65ad680f9c">

After change:
<img width="533" alt="Screenshot 2024-08-29 at 3 13 12 PM" src="https://github.com/user-attachments/assets/0b272824-8661-4b54-9858-2292c7ba4351">
